### PR TITLE
Fix dark mode toggle when Lucide is unavailable

### DIFF
--- a/script.js
+++ b/script.js
@@ -451,6 +451,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- LÓGICA DO TEMA (CLARO/ESCURO) ---
+    const renderLucideIcons = () => {
+        if (window.lucide && typeof window.lucide.createIcons === 'function') {
+            window.lucide.createIcons();
+        }
+    };
+
     const applyTheme = (theme) => {
         if (theme === 'light') {
             document.body.classList.add('light-theme');
@@ -459,7 +465,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.body.classList.remove('light-theme');
             themeToggleBtn.innerHTML = '<i data-lucide="sun"></i>';
         }
-        lucide.createIcons(); // Recria os ícones após mudar o HTML
+        renderLucideIcons(); // Recria os ícones após mudar o HTML
     };
 
     const toggleTheme = () => {
@@ -476,6 +482,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const savedTheme = localStorage.getItem('aurumTheme') || 'dark';
         applyTheme(savedTheme);
         renderAll();
+        renderLucideIcons();
     };
     
     const renderAll = () => {


### PR DESCRIPTION
## Summary
- guard the icon rendering logic so the theme toggle no longer crashes when the Lucide CDN is unreachable
- reuse the guarded renderer during initialization to ensure the correct icon appears

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f7f17f84833393c6f6c9935a8c22