### PR TITLE
Expand dark mode styling to page background

### DIFF
--- a/script.js
+++ b/script.js
@@ -451,6 +451,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- LÓGICA DO TEMA (CLARO/ESCURO) ---
+    const renderLucideIcons = () => {
+        if (window.lucide && typeof window.lucide.createIcons === 'function') {
+            window.lucide.createIcons();
+        }
+    };
+
     const applyTheme = (theme) => {
         if (theme === 'light') {
             document.body.classList.add('light-theme');
@@ -459,7 +465,7 @@ document.addEventListener('DOMContentLoaded', () => {
             document.body.classList.remove('light-theme');
             themeToggleBtn.innerHTML = '<i data-lucide="sun"></i>';
         }
-        lucide.createIcons(); // Recria os ícones após mudar o HTML
+        renderLucideIcons(); // Recria os ícones após mudar o HTML
     };
 
     const toggleTheme = () => {
@@ -476,6 +482,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const savedTheme = localStorage.getItem('aurumTheme') || 'dark';
         applyTheme(savedTheme);
         renderAll();
+        renderLucideIcons();
     };
     
     const renderAll = () => {

--- a/style.css
+++ b/style.css
@@ -28,6 +28,8 @@
     --text-secondary: var(--color-text-secondary-dark-theme);
     --shadow-light: 0 4px 15px rgba(0, 0, 0, 0.2);
     --shadow-heavy: 0 8px 30px rgba(0, 0, 0, 0.4);
+    --background-pattern: radial-gradient(circle at 10% 20%, rgba(192, 154, 88, 0.18), transparent 55%),
+                          radial-gradient(circle at 80% 90%, rgba(140, 59, 74, 0.16), transparent 55%);
     
     --font-primary: 'Poppins', sans-serif;
     --font-secondary: 'Cormorant Garamond', serif;
@@ -45,6 +47,8 @@ body.light-theme {
     --text-secondary: var(--color-text-secondary-light-theme);
     --shadow-light: 0 4px 15px rgba(0, 0, 0, 0.1);
     --shadow-heavy: 0 8px 30px rgba(0, 0, 0, 0.15);
+    --background-pattern: radial-gradient(circle at 10% 20%, rgba(192, 154, 88, 0.35), transparent 50%),
+                          radial-gradient(circle at 80% 90%, rgba(140, 59, 74, 0.25), transparent 55%);
 }
 
 * {
@@ -59,8 +63,7 @@ body {
     color: var(--text-primary);
     line-height: 1.6;
     overflow-x: hidden;
-    background: radial-gradient(circle at 10% 20%, rgba(192, 154, 88, 0.1), transparent 50%),
-                radial-gradient(circle at 80% 90%, rgba(140, 59, 74, 0.1), transparent 50%);
+    background-image: var(--background-pattern);
     background-attachment: fixed;
     transition: background-color 0.4s, color 0.4s;
 }


### PR DESCRIPTION
## Summary
- add theme-aware background gradient variables so the entire page respects the active theme
- apply the gradients through the body background image for consistent light and dark appearances

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3f7f17f84833393c6f6c9935a8c22